### PR TITLE
add CF dep, import elements so it will be properly extended

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+*~
 *.jl.*.cov
 *.jl.cov
 *.jl.mem

--- a/Project.toml
+++ b/Project.toml
@@ -1,10 +1,11 @@
 name = "AtomGraphs"
 uuid = "5a360db7-3336-4c46-b5a1-be4fe079ea55"
 authors = ["Rachel Kurchin <rkurchin@cmu.edu> and contributors"]
-version = "0.1.0"
+version = "0.1.1"
 
 [deps]
 Cairo = "159f3aea-2a34-519c-b102-8c37f9878175"
+ChemistryFeaturization = "6c925690-434a-421d-aea7-51398c5b007a"
 Colors = "5ae59095-9a9b-59fe-a467-6f913c188581"
 Conda = "8f4d0f93-b110-5947-807f-2305c1781a2d"
 Fontconfig = "186bb1d3-e1f7-5a2c-a377-96d770f13627"

--- a/Project.toml
+++ b/Project.toml
@@ -21,6 +21,7 @@ Xtals = "ede5f01d-793e-4c47-9885-c447d1f18d6d"
 
 [compat]
 Cairo = "1"
+ChemistryFeaturization = "0.7"
 Colors = "0.12"
 Conda = "1.6"
 Fontconfig = "0.4"

--- a/deps/build.jl~
+++ b/deps/build.jl~
@@ -1,8 +1,0 @@
-using Conda
-
-Conda.add("ase", channel = "conda-forge")
-Conda.add("pymatgen", channel = "conda-forge")
-if "mkl" in Conda._installed_packages()
-    Conda.rm("mkl")
-    Conda.add("mkl")
-end

--- a/src/AtomGraphs.jl
+++ b/src/AtomGraphs.jl
@@ -8,6 +8,8 @@ using Xtals
 #rc[:paths][:crystals] = @__DIR__ # so that Xtals.jl knows where things are
 using MolecularGraph
 
+import ChemistryFeaturization: elements
+
 include("atomgraph.jl")
 export AtomGraph, elements, visualize
 


### PR DESCRIPTION
I realized the way it was, when I tried to update AtomicGraphNets, it got confused and thought there were two separate `elements` functions...