### PR TITLE
make visualize Pluto compatible

### DIFF
--- a/src/atomgraph.jl
+++ b/src/atomgraph.jl
@@ -277,5 +277,5 @@ function visualize(ag::AtomGraph)
         nodelabel = ag.elements,
         edgelinewidth = graph_edgewidths(ag),
     )
-    display(plt)
+    # display(plt)
 end


### PR DESCRIPTION
Hopefully, we can make the visualisation of AtomGraphs Pluto compatible without hurting compatibility with Jupyter by simply returning the graph object. 