### PR TITLE
explicitly specify `pymatgen` version to be used

### DIFF
--- a/deps/build.jl
+++ b/deps/build.jl
@@ -1,3 +1,3 @@
 using Conda
 
-Conda.add("pymatgen", channel = "conda-forge")
+Conda.add("pymatgen=2022.3.7", channel="conda-forge")

--- a/src/graph_building.jl
+++ b/src/graph_building.jl
@@ -34,7 +34,7 @@ function build_graph(
 
     if use_voronoi
         @info "Note that building neighbor lists and edge weights via the Voronoi method requires the assumption of periodic boundaries. If you are building a graph for a molecule, you probably do not want this..."
-        s = pyimport_conda("pymatgen.core.structure", "pymatgen", "conda-forge")
+        s = pyimport_conda("pymatgen.core.structure", "pymatgen=2022.3.7", "conda-forge")
         struc = s.Structure.from_file(file_path)
         weight_mat = weights_voronoi(struc)
         return weight_mat, atom_ids, struc
@@ -119,7 +119,7 @@ Build graph using neighbors from faces of Voronoi polyedra and weights from area
 """
 function weights_voronoi(struc)
     num_atoms = size(struc)[1]
-    sa = pyimport_conda("pymatgen.analysis.structure_analyzer", "pymatgen", "conda-forge")
+    sa = pyimport_conda("pymatgen.analysis.structure_analyzer", "pymatgen=2022.3.7", "conda-forge")
     vc = sa.VoronoiConnectivity(struc)
     conn = vc.connectivity_array
     weight_mat = zeros(Float32, num_atoms, num_atoms)
@@ -193,4 +193,3 @@ function neighbor_list(crys::Crystal; cutoff_radius::Real = 8.0)
 end
 
 # TODO: graphs from SMILES via OpenSMILES.jl
-


### PR DESCRIPTION
When the `pymatgen` version is not specified, the version automatically
resolved to and installed is the latest version, which can lead to
non-deterministic behaviour and possibly, to errors.

Due to this non-deterministic behaviour, currently, the tests also
error out.

```
Got exception outside of a `@test`
  PyError ($(Expr(:escape, :(ccall(#= /home/thazhemadam/.julia/packages/PyCall/7a7w0/src/pyfncall.jl:43 =# @pysym(:PyObject_Call), PyPtr, (PyPtr, PyPtr, PyPtr), o, pyargsptr, kw))))) <class 'ImportError'>
  ImportError("/home/thazhemadam/packages/julias/julia-1.7/bin/../lib/julia/libstdc++.so.6: version `GLIBCXX_3.4.30' not found (required by /home/thazhemadam/.julia/conda/3/lib/python3.9/site-packages/scipy/fft/_pocketfft/pypocketfft.cpython-39-x86_64-linux-gnu.so)")
    File "/home/thazhemadam/.julia/conda/3/lib/python3.9/site-packages/pymatgen/core/structure.py", line 2449, in from_file
      from pymatgen.io.vasp import Chgcar, Vasprun
    File "/home/thazhemadam/.julia/conda/3/lib/python3.9/site-packages/pymatgen/io/vasp/__init__.py", line 12, in <module>
      from .outputs import (
    File "/home/thazhemadam/.julia/conda/3/lib/python3.9/site-packages/pymatgen/io/vasp/outputs.py", line 45, in <module>
      from pymatgen.electronic_structure.dos import CompleteDos, Dos
    File "/home/thazhemadam/.julia/conda/3/lib/python3.9/site-packages/pymatgen/electronic_structure/dos.py", line 16, in <module>
      from scipy.signal import hilbert
    File "/home/thazhemadam/.julia/conda/3/lib/python3.9/site-packages/scipy/signal/__init__.py", line 309, in <module>
      from . import _sigtools, windows
    File "/home/thazhemadam/.julia/conda/3/lib/python3.9/site-packages/scipy/signal/windows/__init__.py", line 41, in <module>
      from ._windows import *
    File "/home/thazhemadam/.julia/conda/3/lib/python3.9/site-packages/scipy/signal/windows/_windows.py", line 7, in <module>
      from scipy import linalg, special, fft as sp_fft
    File "/home/thazhemadam/.julia/conda/3/lib/python3.9/site-packages/scipy/fft/__init__.py", line 91, in <module>
      from ._helper import next_fast_len
    File "/home/thazhemadam/.julia/conda/3/lib/python3.9/site-packages/scipy/fft/_helper.py", line 3, in <module>
      from ._pocketfft import helper as _helper
    File "/home/thazhemadam/.julia/conda/3/lib/python3.9/site-packages/scipy/fft/_pocketfft/__init__.py", line 3, in <module>
      from .basic import *
    File "/home/thazhemadam/.julia/conda/3/lib/python3.9/site-packages/scipy/fft/_pocketfft/basic.py", line 6, in <module>
      from . import pypocketfft as pfft
```

The root cause of the error seems to be the absence of `GLIBCXX_3.4.30`
in Julia's library. `GLIBCXX_3.4.29` is the highest version available to
a standard install of Julia. [1]
Locally, one could possibly switch out the default `libstdc++.so` shipped
with Julia with an appropriate `libstdc++.so` that has `GLIBCXX_3.4.30`,
but this is obviously problematic for different use-cases and contexts
such as end-user and third-party user requirements, CI, sysimages
to name a few.

`v2022.3.7` of `pymatgen` seems to be the last version that seems to
reliably work without relying on `GLIBC_3.4.30`.

Thus, explicitly specify `v2022.3.7` as the version of `pymatgen` to
be used.

[1] https://discourse.julialang.org/t/glibcxx-version-not-found/82209